### PR TITLE
fix: 云开发 agent 云托管模板对话无历史上下文数据

### DIFF
--- a/cloudrunfunctions/cloudbase-agent/src/chat_context.service.ts
+++ b/cloudrunfunctions/cloudbase-agent/src/chat_context.service.ts
@@ -193,7 +193,7 @@ ${handleSearchDBResult.prompt}
     let fixHistoryList = this.fixHistory(history)
 
     // 如果没有传入历史信息，则从数据库中查询
-    if (fixHistoryList?.length > 0) {
+    if (!fixHistoryList || fixHistoryList?.length === 0) {
       fixHistoryList = await this.chatHistoryService.queryForLLM(
         this.botContext.info.botId,
         undefined,


### PR DESCRIPTION
<img width="701" height="800" alt="Clipboard_Screenshot_1765514682" src="https://github.com/user-attachments/assets/74610fea-c56a-4d4b-8c8e-36b2e10f6448" />
