### PR TITLE
feat: cloudbase-agent 提供转人工回应配置

### DIFF
--- a/cloudrunfunctions/cloudbase-agent/bot-config.yaml
+++ b/cloudrunfunctions/cloudbase-agent/bot-config.yaml
@@ -72,3 +72,7 @@ voiceSettings:
 # example:
 # enable: true
 multiConversationEnable: false
+
+# 转人工回应
+manualKeyWord: "人工"
+manualReply: ""

--- a/cloudrunfunctions/cloudbase-agent/src/bot_config.ts
+++ b/cloudrunfunctions/cloudbase-agent/src/bot_config.ts
@@ -32,6 +32,8 @@ export interface IBotConfig {
     outputType?: number;
   };
   multiConversationEnable: boolean;
+  manualKeyWord: string;
+  manualReply:string;
 }
 
 export class BotConfig {

--- a/cloudrunfunctions/cloudbase-agent/src/chat_wx.service.ts
+++ b/cloudrunfunctions/cloudbase-agent/src/chat_wx.service.ts
@@ -23,6 +23,7 @@ import {
 } from './constant'
 import { LLMCommunicator } from './llm'
 import { WxApiService } from './wx_api.service'
+import { botConfig } from './bot_config'
 
 export interface WxChatOptions {
   botId: string;
@@ -87,6 +88,13 @@ export class WxChatService {
 
       // 获取文本内容
       const content = await this.getWxChatContent(options)
+
+      // 处理人工回复
+      if (botConfig?.manualKeyWord && content === botConfig.manualKeyWord) {
+        replyMsgData.content = botConfig?.manualReply || '未配备客服联系方式';
+        skipAI = true;
+      }
+
       // 处理未认证订阅号/服务号同步响应的情况
       if (
         [TRIGGER_SRC_WX_SUBSCRIPTION, TRIGGER_SRC_WX_SERVICE].includes(


### PR DESCRIPTION
通过配置``bot-config.yaml``文件以下字段触发回应
```
# 转人工回应
manualKeyWord: "人工"
manualReply: "联系123456"
```